### PR TITLE
Upgrade packages with security warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,9 +5,9 @@
   "dependencies": {
     "backbone": "~1.1.0",
     "underscore": "~1.5.2",
-    "jquery": "~2.0.3",
+    "jquery": "~3.3",
     "normalize-css": "~2.1.3",
-    "zooniverse": "0.6.10"
+    "zooniverse": "0.8.11"
   },
   "overrides": {
     "backbone": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "stylus-brunch": "1.8.1",
     "sync-exec": "^0.5.0",
     "translator-seed": "0.1.2",
-    "uglify-js": "2.4.15",
-    "uglify-js-brunch": "1.7.7"
+    "uglify-js": "~2.6",
+    "uglify-js-brunch": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "aws-sdk": "~2.1.36",
-    "brunch": "^1.7.1",
+    "brunch": "^2.10.0",
     "cheerio": "0.12.4",
     "clean-css": "1.0.12",
     "clean-css-brunch": "1.7.1",


### PR DESCRIPTION
Updates jquery, zooniverse.js, uglify and uglify-js-brunch.

`brunch build` throws a bunch of v8 errors when I run it with node 6, but seems to work. There might be outdated code in `build.js` that needs to be updated.

This supersedes the zooniverse.js upgrade in #42.